### PR TITLE
Fix a number of compiler warnings (mainly unused variables)

### DIFF
--- a/src/broadphase/q3DynamicAABBTree.cpp
+++ b/src/broadphase/q3DynamicAABBTree.cpp
@@ -244,11 +244,12 @@ i32 q3DynamicAABBTree::Balance( i32 iA )
 	if ( A->IsLeaf( ) || A->height == 1 )
 		return iA;
 
-	//      A
-	//    /   \
-	//   B     C
-	//  / \   / \
-	// D   E F   G
+	/*      A
+	      /   \
+	     B     C
+	    / \   / \
+	   D   E F   G
+	*/
 
 	i32 iB = A->left;
 	i32 iC = A->right;

--- a/src/collision/q3Box.cpp
+++ b/src/collision/q3Box.cpp
@@ -55,8 +55,6 @@ bool q3Box::Raycast( const q3Transform& tx, q3RaycastData* raycast ) const
 	q3Transform world = q3Mul( tx, local );
 	q3Vec3 d = q3MulT( world.rotation, raycast->dir );
 	q3Vec3 p = q3MulT( world, raycast->start );
-	r32 tfirst = 0;
-	r32 tlast = raycast->t;
 	const r32 epsilon = r32( 1.0e-8 );
 	r32 tmin = 0;
 	r32 tmax = raycast->t;

--- a/src/dynamics/q3Body.cpp
+++ b/src/dynamics/q3Body.cpp
@@ -381,7 +381,6 @@ const q3Quaternion q3Body::GetQuaternion( ) const
 //--------------------------------------------------------------------------------------------------
 void q3Body::Render( q3Render* render ) const
 {
-	q3Transform tx = m_tx;
 	bool awake = IsAwake( );
 	q3Box* box = m_boxes;
 

--- a/src/dynamics/q3ContactManager.cpp
+++ b/src/dynamics/q3ContactManager.cpp
@@ -36,8 +36,8 @@
 //--------------------------------------------------------------------------------------------------
 q3ContactManager::q3ContactManager( q3Stack* stack )
 	: m_stack( stack )
-	, m_broadphase( this )
 	, m_allocator( sizeof( q3ContactConstraint ), 256 )
+	, m_broadphase( this )
 {
 	m_contactList = NULL;
 	m_contactCount = 0;

--- a/src/scene/q3Scene.cpp
+++ b/src/scene/q3Scene.cpp
@@ -436,7 +436,7 @@ void q3Scene::RayCast( q3QueryCallback *cb, q3RaycastData& rayCast ) const
 void q3Scene::Dump( FILE* file ) const
 {
 	fprintf( file, "// Ensure 64/32-bit memory compatability with the dump contents\n" );
-	fprintf( file, "assert( sizeof( int* ) == %d );\n", sizeof( int* ) );
+	fprintf( file, "assert( sizeof( int* ) == %lu );\n", sizeof( int* ) );
 	fprintf( file, "scene.SetGravity( q3Vec3( %.15lf, %.15lf, %.15lf ) );\n", m_gravity.x, m_gravity.y, m_gravity.z );
 	fprintf( file, "scene.SetAllowSleep( %s );\n", m_allowSleep ? "true" : "false" );
 	fprintf( file, "scene.SetEnableFriction( %s );\n", m_enableFriction ? "true" : "false" );


### PR DESCRIPTION
Just fixes a few minor compiler warnings, unused variables, an initialization ordering one, and a couple about "\" multi-line comments.