### PR TITLE
A couple of optimizations

### DIFF
--- a/src/dynamics/q3ContactManager.cpp
+++ b/src/dynamics/q3ContactManager.cpp
@@ -206,17 +206,17 @@ void q3ContactManager::TestCollisions( void )
 		q3Body *bodyA = A->body;
 		q3Body *bodyB = B->body;
 
+		if( !bodyA->IsAwake( ) && !bodyB->IsAwake( ) )
+		{
+			constraint = constraint->next;
+			continue;
+		}
+
 		if ( !bodyA->CanCollide( bodyB ) )
 		{
 			q3ContactConstraint* next = constraint->next;
 			RemoveContact( constraint );
 			constraint = next;
-			continue;
-		}
-
-		if( !bodyA->IsAwake( ) && !bodyB->IsAwake( ) )
-		{
-			constraint = constraint->next;
 			continue;
 		}
 
@@ -228,7 +228,6 @@ void q3ContactManager::TestCollisions( void )
 			constraint = next;
 			continue;
 		}
-		
 		q3Manifold* manifold = &constraint->manifold;
 		q3Manifold oldManifold = constraint->manifold;
 		q3Vec3 ot0 = oldManifold.tangentVectors[ 0 ];

--- a/src/dynamics/q3ContactManager.cpp
+++ b/src/dynamics/q3ContactManager.cpp
@@ -200,6 +200,7 @@ void q3ContactManager::TestCollisions( void )
 
 	while( constraint )
 	{
+		constraint->m_flags &= ~q3ContactConstraint::eIsland;
 		q3Box *A = constraint->A;
 		q3Box *B = constraint->B;
 		q3Body *bodyA = A->body;

--- a/src/scene/q3Scene.cpp
+++ b/src/scene/q3Scene.cpp
@@ -71,9 +71,6 @@ void q3Scene::Step( )
 	for ( q3Body* body = m_bodyList; body; body = body->m_next )
 		body->m_flags &= ~q3Body::eIsland;
 
-	for ( q3ContactConstraint* c = m_contactManager.m_contactList; c; c = c->next )
-		c->m_flags &= ~q3ContactConstraint::eIsland;
-
 	// Size the stack island, pick worst case size
 	q3Island island;
 	island.m_bodyCapacity = m_bodyCount;


### PR DESCRIPTION
Optimization 1: Running in a profiler I noticed that the Step() function was spending a significant exclusive time (around 70%) resetting the island flag, so I moved it out to earlier where contact list gets iterated.

Optimization 2: Moved skip of sleeping bodies to slightly earlier.

(Side note): I'm evaluating qu3e against PhysX for a pet project. So far it's looking great because it's so much less code and easy to understand, not to mention free open source.

Got some more ideas for optimizations - for example moving sleeping bodies and contacts out to separate linked lists so that no iteration takes place for sleeping bodies. If I get that working I could send a few more pull requests your way.
