### PR TITLE
Switched to dynamic memory for q3Stack.

### DIFF
--- a/src/common/q3Memory.h
+++ b/src/common/q3Memory.h
@@ -50,8 +50,6 @@ inline void q3Free( void* memory )
 //--------------------------------------------------------------------------------------------------
 // q3Stack
 //--------------------------------------------------------------------------------------------------
-// 20MB stack size, change as necessary
-const i32 q3k_stackSize = 1024 * 1024 * 20;
 
 class q3Stack
 {
@@ -66,11 +64,12 @@ public:
 	q3Stack( );
 	~q3Stack( );
 
+	void Reserve( u32 size );
 	void *Allocate( i32 size );
 	void Free( void *data );
 
 private:
-	u8 m_memory[ q3k_stackSize ];
+	u8* m_memory;
 	q3StackEntry* m_entries;
 
 	i32 m_index;
@@ -78,6 +77,7 @@ private:
 	i32 m_allocation;
 	i32 m_entryCount;
 	i32 m_entryCapacity;
+	u32 m_stackSize;
 };
 
 //--------------------------------------------------------------------------------------------------

--- a/src/scene/q3Scene.cpp
+++ b/src/scene/q3Scene.cpp
@@ -75,6 +75,12 @@ void q3Scene::Step( )
 		c->m_flags &= ~q3ContactConstraint::eIsland;
 
 	// Size the stack island, pick worst case size
+	m_stack.Reserve( sizeof( q3Body* ) * m_bodyCount
+	+ sizeof( q3VelocityState ) * m_bodyCount
+	+ sizeof( q3ContactConstraint* ) * m_contactManager.m_contactCount
+	+ sizeof( q3ContactConstraintState ) * m_contactManager.m_contactCount
+	+ sizeof( q3Body* ) * m_bodyCount);
+
 	q3Island island;
 	island.m_bodyCapacity = m_bodyCount;
 	island.m_contactCapacity = m_contactManager.m_contactCount;


### PR DESCRIPTION
I had a use-case where the number of bodies could be anywhere from a few to over a thousand and was not very predictable. At default I was running out of q3Stack space. Didn't want to increase stack size and waste memory, so ended up switching to using dynamic memory and a Reserve() function.
I was also thinking of making it shrink when Reserved request is <10% capacity or something along those lines.

Scenario: Suppose you have a game with the world which is stream-loading and the areas fluctuate in terms of number of bodies, it would be good to have the memory allocated and released based on demand.