### PR TITLE
A q3Transform inverse

### DIFF
--- a/src/math/q3Transform.inl
+++ b/src/math/q3Transform.inl
@@ -122,3 +122,15 @@ inline void q3Identity( q3Transform& tx )
 	q3Identity( tx.position );
 	q3Identity( tx.rotation );
 }
+
+//--------------------------------------------------------------------------------------------------
+inline const q3Transform q3Inverse( const q3Transform& tx )
+{
+	q3Transform inverted;
+	q3Mat3 zero;
+	q3Zero(zero);
+	
+	inverted.rotation = q3Transpose(tx.rotation);
+	inverted.position = q3Mul(zero-inverted.rotation, tx.position);
+	return inverted;
+}


### PR DESCRIPTION
Since this library provides a good mathematical base for various projects I've made a small improvement that allows calculating an inverse of a q3Transform (as defined in http://www.cg.info.hiroshima-cu.ac.jp/~miyazaki/knowledge/teche53.html). When used in a hierarchy of q3Transformed objects it allows easier calculation of a `global position in local space` type conversions.

I didn't really want to also provide an `operator-(void)` so here I just used a `q3Zero` walkaround.