### PR TITLE
Optimisation of q3Transform q3Inverse

### DIFF
--- a/src/math/q3Transform.inl
+++ b/src/math/q3Transform.inl
@@ -127,10 +127,7 @@ inline void q3Identity( q3Transform& tx )
 inline const q3Transform q3Inverse( const q3Transform& tx )
 {
 	q3Transform inverted;
-	q3Mat3 zero;
-	q3Zero(zero);
-	
 	inverted.rotation = q3Transpose(tx.rotation);
-	inverted.position = q3Mul(zero-inverted.rotation, tx.position);
+	inverted.position = q3Mul(inverted.rotation, -tx.position);
 	return inverted;
 }


### PR DESCRIPTION
Last modification of the q3Inverse convinience method, as noticed in #39 it can be simplified to use a vector negation instead of matrix negation.

PS. Thanks for all the explanations @RandyGaul !