### PR TITLE
docs: fix simple typo, paramter -> parameter

### DIFF
--- a/freeglut/freeglut_main.c
+++ b/freeglut/freeglut_main.c
@@ -1582,7 +1582,7 @@ LRESULT CALLBACK fgWindowProc( HWND hWnd, UINT uMsg, WPARAM wParam,
     switch( uMsg )
     {
     case WM_CREATE:
-        /* The window structure is passed as the creation structure paramter... */
+        /* The window structure is passed as the creation structure parameter... */
         window = (SFG_Window *) (((LPCREATESTRUCT) lParam)->lpCreateParams);
         FREEGLUT_INTERNAL_ERROR_EXIT ( ( window != NULL ), "Cannot create window",
                                        "fgWindowProc" );


### PR DESCRIPTION
There is a small typo in freeglut/freeglut_main.c.

Should read `parameter` rather than `paramter`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md